### PR TITLE
Log specific errors from schema change failures

### DIFF
--- a/src/format-message.ts
+++ b/src/format-message.ts
@@ -128,6 +128,18 @@ const formatMessage = (
 
     message += '```\n';
   }
+  
+  if (checkSchemaResult?.diffToPrevious.severity === 'FAILURE') {
+    message += '#### Schema Change Errors\n\n```\n';
+
+    for (const change of checkSchemaResult?.diffToPrevious.changes) {
+      if (change.severity === 'FAILURE') {
+        message += `${error.description}\n`;
+      }
+    }
+
+    message += '```\n';
+  }
 
   info('message', message);
 


### PR DESCRIPTION
**Problem**
The action does a good job of making a comment and notifying the user that there are schema change failures, or giving specific errors from composition validation, however it requires an extra click to expose the fields causing the failure even though we already have this data

**Solution**
Update the formatMessage method to also append a custom message with the schema change failures, just like we do for composition validation

**Demo**
Apollo Schema Check
🔄 Validated your local schema changes against metrics from variant `` for service commons on graph `commons-prod`
🔢 Compared 2 schema changes against 357 operations seen over the last 604800 sec
❌ Found 2 breaking changes

🔗 [View schema check details](https://studio.apollographql.com/graph/commons-prod/operationsCheck/aa873b7a-bcef-4561-a37c-3a02af920192?variant=current)

Schema Change Errors
type `RiskAreaGroup`: field `description` removed

**NOTE**
I eyeballed this change from the logged query response and the code. I'm pretty new to github actions testing so wasn't sure how to exercise it live. But hopefully this is helpful, I know it would be for us!