### PR TITLE
Update passed from value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Apollo Schema Check Action Changelog
 
+## 2.0.2 (September 15, 2022)
+
+- Update `from` parameter format. It seems Apollo no longer wants `sec` included with offsets.
+
 ## 2.0.1 (July 6, 2022)
 
 - Pass `from` parameter to Apollo Studio API as a string instead of a number (see: [https://status.apollographql.com/incidents/c5dvk0tbg5bv](https://status.apollographql.com/incidents/c5dvk0tbg5bv))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-schema-check-action",
   "description": "A GitHub Action to run a schema check with Apollo Studio and post the results as a comment on a Pull Request",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "Ian Sutherland <ian@iansutherland.ca>",
   "license": "MIT",
   "repository": {

--- a/src/get-arguments.ts
+++ b/src/get-arguments.ts
@@ -85,9 +85,9 @@ const getApolloConfigFile = async (file: string): Promise<ApolloConfigFile> => {
 
 const getFromValue = (validationPeriod: string): string => {
   if (validationPeriod.startsWith('P')) {
-    return `${toSeconds(parse(validationPeriod))} sec`;
+    return `${toSeconds(parse(validationPeriod))}`;
   } else if (validationPeriod.match(/^-?\d+$/)) {
-    return `${Math.abs(Number.parseInt(validationPeriod))} sec`;
+    return `${Math.abs(Number.parseInt(validationPeriod))}`;
   } else {
     return validationPeriod;
   }

--- a/test/get-arguments.test.ts
+++ b/test/get-arguments.test.ts
@@ -92,15 +92,15 @@ describe.skip('getQueryVariables', () => {
 
 describe('getFromValue', () => {
   test('negative number of seconds', () => {
-    expect(getFromValue('-86400')).toBe('86400 sec');
+    expect(getFromValue('-86400')).toBe('86400');
   });
 
   test('positive number of seconds', () => {
-    expect(getFromValue('300')).toBe('300 sec');
+    expect(getFromValue('300')).toBe('300');
   });
 
   test('ISO 8601 duration', () => {
-    expect(getFromValue('P2W')).toBe('1209600 sec');
+    expect(getFromValue('P2W')).toBe('1209600');
   });
 
   test('Plain text duration', () => {


### PR DESCRIPTION
Apollo seems to have changed what they want passed as the `from` value _again_ 😔