### PR TITLE
Use negative integer for from duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Apollo Schema Check Action Changelog
 
+## 2.1.1 (November 15, 2022)
+
+- Fix: Use negative from parameter when sending to Apollo backend (@comp615)
+
 ## 2.1.0 (October 31, 2022)
 
 - Include a list of errors in the PR comment (@comp615)

--- a/src/check-schema.ts
+++ b/src/check-schema.ts
@@ -1,7 +1,7 @@
 import { GraphQLClient, gql } from 'graphql-request';
 import { getInput } from '@actions/core';
-import { debug } from './actions-helpers';
 
+import { debug } from './actions-helpers';
 import { getQueryVariables, QueryVariables } from './get-arguments';
 import { formatMessage } from './format-message';
 
@@ -105,7 +105,9 @@ const checkSchema = async (commentIdentifier: string, existingComment: boolean):
 
   try {
     const variables = await getQueryVariables();
+
     debug('Apollo Studio request variables', JSON.stringify(variables, null, 2));
+    
     const data = await graphQLClient.request<ApolloStudioResponse, QueryVariables>(mutation, variables);
 
     return formatMessage(data, variables, commentIdentifier, existingComment);

--- a/src/check-schema.ts
+++ b/src/check-schema.ts
@@ -104,6 +104,7 @@ const checkSchema = async (commentIdentifier: string, existingComment: boolean):
 
   try {
     const variables = await getQueryVariables();
+    debug('Apollo Studio request variables', JSON.stringify(variables, null, 2));
     const data = await graphQLClient.request<ApolloStudioResponse, QueryVariables>(mutation, variables);
 
     return formatMessage(data, variables, commentIdentifier, existingComment);

--- a/src/check-schema.ts
+++ b/src/check-schema.ts
@@ -1,5 +1,6 @@
 import { GraphQLClient, gql } from 'graphql-request';
 import { getInput } from '@actions/core';
+import { debug } from './actions-helpers';
 
 import { getQueryVariables, QueryVariables } from './get-arguments';
 import { formatMessage } from './format-message';

--- a/src/get-arguments.ts
+++ b/src/get-arguments.ts
@@ -85,9 +85,9 @@ const getApolloConfigFile = async (file: string): Promise<ApolloConfigFile> => {
 
 const getFromValue = (validationPeriod: string): string => {
   if (validationPeriod.startsWith('P')) {
-    return `${toSeconds(parse(validationPeriod))}`;
+    return `-${toSeconds(parse(validationPeriod))}`;
   } else if (validationPeriod.match(/^-?\d+$/)) {
-    return `${Math.abs(Number.parseInt(validationPeriod))}`;
+    return `-${Math.abs(Number.parseInt(validationPeriod))}`;
   } else {
     return validationPeriod;
   }

--- a/test/get-arguments.test.ts
+++ b/test/get-arguments.test.ts
@@ -92,15 +92,15 @@ describe.skip('getQueryVariables', () => {
 
 describe('getFromValue', () => {
   test('negative number of seconds', () => {
-    expect(getFromValue('-86400')).toBe('86400');
+    expect(getFromValue('-86400')).toBe('-86400');
   });
 
   test('positive number of seconds', () => {
-    expect(getFromValue('300')).toBe('300');
+    expect(getFromValue('300')).toBe('-300');
   });
 
   test('ISO 8601 duration', () => {
-    expect(getFromValue('P2W')).toBe('1209600');
+    expect(getFromValue('P2W')).toBe('-1209600');
   });
 
   test('Plain text duration', () => {


### PR DESCRIPTION
> Closes #29. According to Apollo support, the from field should be sent in negative seconds when using a relative timestamp. This updates the value we send

### Updated dependencies

> Include a list of newly added or updated dependencies

### Future work

> N/A

### Checklist

- [ ] Have you fully tested your PR locally?
- [ X ] Have you written thorough tests for your work?
- [ X ] Have you made a CHANGELOG entry?
