### PR TITLE
Prioritize Schema Composition Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Apollo Schema Check Action Changelog
 
+## Unreleased
+
+- Fix: action now properly fails when schema build fails (@comp615)
+
 ## 2.1.0 (October 31, 2022)
 
 - Include a list of errors in the PR comment (@comp615)

--- a/src/format-message.ts
+++ b/src/format-message.ts
@@ -85,8 +85,8 @@ const formatMessage = (
   const checkSchemaResult = output.service.checkPartialSchema.checkSchemaResult;
   const compositionValidationResult = output.service.checkPartialSchema.compositionValidationResult;
 
-  if (alwaysComment !== 'true' && checkSchemaResult === null) {
-    debug('alwaysComment is false and number of operations is null');
+  if (alwaysComment !== 'true' && checkSchemaResult === null && compositionValidationResult.compositionSuccess) {
+    debug('alwaysComment is false, number of operations is null and schema build was successful');
     debug('output', output);
 
     return;


### PR DESCRIPTION
> Description of changes
Changes the logic a bit so that we also allow for the possibility of a build failure before we early exit when alwaysComment is false

Fixes #32

### Checklist

- [ ] Have you fully tested your PR locally?
- [ ] Have you written thorough tests for your work?
- [ ] Have you made a CHANGELOG entry?
